### PR TITLE
One-liner to fix bundler dependency issues

### DIFF
--- a/mondrian-olap.gemspec
+++ b/mondrian-olap.gemspec
@@ -6,6 +6,7 @@
 Gem::Specification.new do |s|
   s.name = %q{mondrian-olap}
   s.version = "0.3.0"
+  s.platform = %q{java}
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = [%q{Raimonds Simanovskis}]


### PR DESCRIPTION
Raimonds,
This one-liner fixed a problem I had where bundler would think that mondrian-olap (when installed via Git in my Gemfile) was a CRuby gem instead of a JRuby gem.  Bundler then thought mondrian-olap wanted a CRuby version of nokogiri instead of the JRuby one we had installed and would crap out.

Hope this helps!
Larry
