### PR TITLE
Specs need ActiveRecord ~> 4.0.0

### DIFF
--- a/mondrian-olap.gemspec
+++ b/mondrian-olap.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "jdbc-postgres"
   gem.add_development_dependency "jdbc-luciddb"
   gem.add_development_dependency "jdbc-jtds", "~> 1.2.8" # version 1.3 is not compatible with Java 6
-  gem.add_development_dependency "activerecord"
+  gem.add_development_dependency "activerecord", "~> 4.0.0"
   gem.add_development_dependency "activerecord-jdbc-adapter"
   gem.add_development_dependency "activerecord-oracle_enhanced-adapter"
   gem.add_development_dependency "pry"


### PR DESCRIPTION
(related to #32)

I could only make the specs run correctly with ActiveRecord ~> 4.0.0. This pull request modifies `mondrian-olap.gemspec` to require that version.

