### PR TITLE
Fix order of AXIS_ALIASES

### DIFF
--- a/lib/mondrian/olap/query.rb
+++ b/lib/mondrian/olap/query.rb
@@ -34,7 +34,7 @@ module Mondrian
         end
       end
 
-      AXIS_ALIASES = %w(columns rows pages sections chapters)
+      AXIS_ALIASES = %w(columns rows pages chapters sections)
       AXIS_ALIASES.each_with_index do |axis, i|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{axis}(*axis_members)


### PR DESCRIPTION
According to [Mondrian's javadoc](http://javadoc.pentaho.com/mondrian360/mondrian/olap/AxisOrdinal.StandardAxisOrdinal.html), the order of the axis aliases is:

  - Columns
  - Rows
  - Pages
  - Chapters
  - Sections

This PR reflects that. 