### PR TITLE
Use olap4j parseIdentifier in extract_dimension_name

### DIFF
--- a/lib/mondrian/olap/query.rb
+++ b/lib/mondrian/olap/query.rb
@@ -380,9 +380,12 @@ module Mondrian
       end
 
       def extract_dimension_name(full_name)
-        if full_name =~ /\A[^\[]*\[([^\]]+)\]/
-          $1
+        begin
+          sl = org.olap4j.mdx.IdentifierNode.parseIdentifier(full_name).getSegmentList
+        rescue Java::JavaLang::IllegalArgumentException
+          return nil
         end
+        sl.get(0).name
       end
     end
   end


### PR DESCRIPTION
I ran into this bug, which I couldn't find an explanation for. 

I had a [`Query`](https://github.com/rsim/mondrian-olap/blob/master/lib/mondrian/olap/query.rb) instance which had a `where` clause of the form:

```ruby
["[Geography].[Region].&[1]", "[Date].[Year].[2015]"]
```

The result of `Query#to_mdx` call, as expected, was:

```
SELECT NON EMPTY {[Measures].[RCA], [Measures].[FOB US]} ON COLUMNS,
NON EMPTY [Export HS].[HS4].Members ON ROWS
FROM [exports]
WHERE ([Geography].[Region].&[1], [Date].[Year].[2015])
```

However, after **exactly** 13 calls (!), the `WHERE` clause generated by [`Query#where_to_mdx`](https://github.com/rsim/mondrian-olap/blob/master/lib/mondrian/olap/query.rb#L350) was `{[Geography].[Region].&[1], [Date].[Year].[2015]}` (i.e., a *set* instead of a tuple).

I traced that to [`Query#extract_dimension_name`](https://github.com/rsim/mondrian-olap/blob/master/lib/mondrian/olap/query.rb#L382). For some reason, after those 13 calls, the RE didn't match the identifiers in the `WHERE` clause. Replacing that RE match with [`olap4j`'s `parseIdentifier`](http://www.olap4j.org/api/org/olap4j/mdx/IdentifierNode.html#parseIdentifier(java.lang.String)) fixed that behaviour.

I'm officially stumped by this bug. Bug in JRuby, maybe?

