### PR TITLE
Set single role as a union role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 services:
   - mysql
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 env:
   global:


### PR DESCRIPTION
Can be used as a workaround for a Mondrian bug which does not allow access to ragged dimensions when using a single role.