### PR TITLE
Olap connection should handle "instance" parameter for both SQL driver equally

### DIFF
--- a/lib/mondrian/olap/connection.rb
+++ b/lib/mondrian/olap/connection.rb
@@ -314,7 +314,6 @@ module Mondrian
         string + (@params[:catalog] ? "Catalog=#{catalog_uri}" : "CatalogContent=#{quote_string(catalog_content)}")
       end
 
-
       def jdbc_uri_generic(options = {})
         uri_prefix = options[:uri_prefix] || "jdbc:#{@driver}://"
         port = @params[:port] || options[:default_port]
@@ -374,13 +373,11 @@ module Mondrian
         database: 'databaseName',
         integrated_security: 'integratedSecurity',
         application_name: 'applicationName',
-        instance_name: 'instanceName'
+        instance_name: 'instanceName',
+        instance: 'instanceName'
       }
 
       def jdbc_uri_sqlserver
-        if !@params[:port] && @params[:instance]
-          @params[:host] = "#{@params[:host]}\\#{@params[:instance]}"
-        end
         jdbc_uri_generic(
           uri_prefix: 'jdbc:sqlserver://', add_database: false, separator: ';', first_separator: ';',
           default_properties: uri_default_param_properties(JDBC_SQLSERVER_PARAM_PROPERTIES)

--- a/lib/mondrian/olap/connection.rb
+++ b/lib/mondrian/olap/connection.rb
@@ -318,7 +318,7 @@ module Mondrian
       def jdbc_uri_generic(options = {})
         uri_prefix = options[:uri_prefix] || "jdbc:#{@driver}://"
         port = @params[:port] || options[:default_port]
-        uri = "#{uri_prefix}#{@params[:host]}#{port && ":#{port}"}"
+        uri = "#{uri_prefix}#{@params[:host]}#{port && ":#{port}" || @params[:instance] && "\\#{@params[:instance]}"}"
         uri += "/#{@params[:database]}" if @params[:database] && options[:add_database] != false
         properties = new_empty_properties
         properties.merge!(options[:default_properties]) if options[:default_properties].is_a?(Hash)

--- a/lib/mondrian/olap/connection.rb
+++ b/lib/mondrian/olap/connection.rb
@@ -289,6 +289,14 @@ module Mondrian
         true
       end
 
+      def jdbc_uri
+        if respond_to?(method_name = "jdbc_uri_#{@driver}", true)
+          send method_name
+        else
+          raise ArgumentError, 'unknown JDBC driver'
+        end
+      end
+
       private
 
       def connection_string
@@ -306,13 +314,6 @@ module Mondrian
         string + (@params[:catalog] ? "Catalog=#{catalog_uri}" : "CatalogContent=#{quote_string(catalog_content)}")
       end
 
-      def jdbc_uri
-        if respond_to?(method_name = "jdbc_uri_#{@driver}", true)
-          send method_name
-        else
-          raise ArgumentError, 'unknown JDBC driver'
-        end
-      end
 
       def jdbc_uri_generic(options = {})
         uri_prefix = options[:uri_prefix] || "jdbc:#{@driver}://"

--- a/lib/mondrian/olap/connection.rb
+++ b/lib/mondrian/olap/connection.rb
@@ -318,7 +318,7 @@ module Mondrian
       def jdbc_uri_generic(options = {})
         uri_prefix = options[:uri_prefix] || "jdbc:#{@driver}://"
         port = @params[:port] || options[:default_port]
-        uri = "#{uri_prefix}#{@params[:host]}#{port && ":#{port}" || @params[:instance] && "\\#{@params[:instance]}"}"
+        uri = "#{uri_prefix}#{@params[:host]}#{port && ":#{port}"}"
         uri += "/#{@params[:database]}" if @params[:database] && options[:add_database] != false
         properties = new_empty_properties
         properties.merge!(options[:default_properties]) if options[:default_properties].is_a?(Hash)
@@ -378,6 +378,9 @@ module Mondrian
       }
 
       def jdbc_uri_sqlserver
+        if !@params[:port] && @params[:instance]
+          @params[:host] = "#{@params[:host]}\\#{@params[:instance]}"
+        end
         jdbc_uri_generic(
           uri_prefix: 'jdbc:sqlserver://', add_database: false, separator: ';', first_separator: ';',
           default_properties: uri_default_param_properties(JDBC_SQLSERVER_PARAM_PROPERTIES)

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -92,4 +92,59 @@ describe "Connection" do
 
   end
 
+  describe "jdbc_uri" do
+    before(:all) { @olap_connection = Mondrian::OLAP::Connection }
+
+    describe "MSSQL" do
+      it "should return a valid JDBC URI" do
+        @olap_connection.new(
+          driver: 'mssql',
+          host: 'example.com',
+          port: 1234,
+          instance: 'MSSQLSERVER',
+          database: 'example_db',
+          domain: 'win_domain'
+        ).jdbc_uri.should == 'jdbc:jtds:sqlserver://example.com:1234/example_db;instance=MSSQLSERVER;domain=win_domain'
+      end
+    end
+
+    describe "SQL Server" do
+      it "should return a valid JDBC URI with port" do
+        @olap_connection.new(
+          driver: 'sqlserver',
+          host: 'example.com',
+          port: 1234,
+          instance: 'MSSQLSERVER',
+          database: 'example_db'
+        ).jdbc_uri.should == 'jdbc:sqlserver://example.com:1234;databaseName=example_db'
+      end
+
+      it "should return a valid JDBC URI with instance name" do
+        @olap_connection.new(
+          driver: 'sqlserver',
+          host: 'example.com',
+          instance: 'MSSQLSERVER',
+          database: 'example_db'
+        ).jdbc_uri.should == 'jdbc:sqlserver://example.com\MSSQLSERVER;databaseName=example_db'
+      end
+
+      it "should return a valid JDBC URI with instance name as property" do
+        @olap_connection.new(
+          driver: 'sqlserver',
+          host: 'example.com',
+          properties: {
+            instanceName: "MSSQLSERVER"
+          }
+        ).jdbc_uri.should == 'jdbc:sqlserver://example.com;instanceName=MSSQLSERVER'
+      end
+
+      it "should return a valid JDBC URI with enabled integratedSecurity" do
+        @olap_connection.new(
+          driver: 'sqlserver',
+          host: 'example.com',
+          integrated_security: 'true'
+        ).jdbc_uri.should == 'jdbc:sqlserver://example.com;integratedSecurity=true'
+      end
+    end
+  end
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -95,7 +95,7 @@ describe "Connection" do
   describe "jdbc_uri" do
     before(:all) { @olap_connection = Mondrian::OLAP::Connection }
 
-    describe "MSSQL" do
+    describe "MS SQL jTDS driver" do
       it "should return a valid JDBC URI" do
         @olap_connection.new(
           driver: 'mssql',

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -109,23 +109,14 @@ describe "Connection" do
     end
 
     describe "SQL Server" do
-      it "should return a valid JDBC URI with port" do
+      it "should return a valid JDBC URI" do
         @olap_connection.new(
           driver: 'sqlserver',
           host: 'example.com',
           port: 1234,
           instance: 'MSSQLSERVER',
           database: 'example_db'
-        ).jdbc_uri.should == 'jdbc:sqlserver://example.com:1234;databaseName=example_db'
-      end
-
-      it "should return a valid JDBC URI with instance name" do
-        @olap_connection.new(
-          driver: 'sqlserver',
-          host: 'example.com',
-          instance: 'MSSQLSERVER',
-          database: 'example_db'
-        ).jdbc_uri.should == 'jdbc:sqlserver://example.com\MSSQLSERVER;databaseName=example_db'
+        ).jdbc_uri.should == 'jdbc:sqlserver://example.com:1234;databaseName=example_db;instanceName=MSSQLSERVER'
       end
 
       it "should return a valid JDBC URI with instance name as property" do


### PR DESCRIPTION
Currently, only for `mssql` driver instance parameter can be used, it is ignored for `sqlserver` driver. With this patch, the instance param will result in a connection string like `jdbc:sqlserver://example.com\MSSQLSERVER`.