### PR TITLE
Add query builder filter_last method

### DIFF
--- a/lib/mondrian/olap/query.rb
+++ b/lib/mondrian/olap/query.rb
@@ -81,6 +81,12 @@ module Mondrian
         self
       end
 
+      def filter_last(condition, options = {})
+        validate_current_set
+        add_last_set_function :filter, condition, options[:as]
+        self
+      end
+
       def filter_nonempty
         validate_current_set
         filter('NOT ISEMPTY(S.CURRENT)', as: 'S')

--- a/lib/mondrian/olap/query.rb
+++ b/lib/mondrian/olap/query.rb
@@ -36,7 +36,7 @@ module Mondrian
 
       AXIS_ALIASES = %w(columns rows pages chapters sections)
       AXIS_ALIASES.each_with_index do |axis, i|
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{axis}(*axis_members)
             axis(#{i}, *axis_members)
           end
@@ -44,94 +44,85 @@ module Mondrian
       end
 
       %w(crossjoin nonempty_crossjoin).each do |method|
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{method}(*axis_members)
-            raise ArgumentError, "cannot use #{method} method before axis or with_set method" unless @current_set
+            validate_current_set
             raise ArgumentError, "specify set of members for #{method} method" if axis_members.empty?
             members = axis_members.length == 1 && axis_members[0].is_a?(Array) ? axis_members[0] : axis_members
-            @current_set.replace [:#{method}, @current_set.clone, members]
+            add_current_set_function :#{method}, members
             self
           end
         RUBY
       end
 
       def except(*axis_members)
-        raise ArgumentError, "cannot use except method before axis or with_set method" unless @current_set
+        validate_current_set
         raise ArgumentError, "specify set of members for except method" if axis_members.empty?
         members = axis_members.length == 1 && axis_members[0].is_a?(Array) ? axis_members[0] : axis_members
-        if [:crossjoin, :nonempty_crossjoin].include? @current_set[0]
-          @current_set[2] = [:except, @current_set[2], members]
-        else
-          @current_set.replace [:except, @current_set.clone, members]
-        end
+        add_last_set_function :except, members
         self
       end
 
       def nonempty
-        raise ArgumentError, "cannot use nonempty method before axis method" unless @current_set
-        @current_set.replace [:nonempty, @current_set.clone]
+        validate_current_set
+        add_current_set_function :nonempty
         self
       end
 
       def distinct
-        raise ArgumentError, "cannot use distinct method before axis method" unless @current_set
-        @current_set.replace [:distinct, @current_set.clone]
+        validate_current_set
+        add_current_set_function :distinct
         self
       end
 
       def filter(condition, options = {})
-        raise ArgumentError, "cannot use filter method before axis or with_set method" unless @current_set
-        @current_set.replace [:filter, @current_set.clone, condition]
-        @current_set << options[:as] if options[:as]
+        validate_current_set
+        add_current_set_function :filter, condition, options[:as]
         self
       end
 
       def filter_nonempty
-        raise ArgumentError, "cannot use filter_nonempty method before axis or with_set method" unless @current_set
-        condition = "NOT ISEMPTY(S.CURRENT)"
-        @current_set.replace [:filter, @current_set.clone, condition, 'S']
-        self
+        validate_current_set
+        filter('NOT ISEMPTY(S.CURRENT)', as: 'S')
       end
 
       def generate(*axis_members)
-        raise ArgumentError, "cannot use generate method before axis or with_set method" unless @current_set
+        validate_current_set
         all = if axis_members.last == :all
           axis_members.pop
           'ALL'
         end
         raise ArgumentError, "specify set of members for generate method" if axis_members.empty?
         members = axis_members.length == 1 && axis_members[0].is_a?(Array) ? axis_members[0] : axis_members
-        @current_set.replace [:generate, @current_set.clone, members]
-        @current_set << all if all
+        add_current_set_function :generate, members, all
         self
       end
 
       VALID_ORDERS = ['ASC', 'BASC', 'DESC', 'BDESC']
 
       def order(expression, direction)
-        raise ArgumentError, "cannot use order method before axis or with_set method" unless @current_set
+        validate_current_set
         direction = direction.to_s.upcase
-        raise ArgumentError, "invalid order direction #{direction.inspect}," <<
+        raise ArgumentError, "invalid order direction #{direction.inspect}," \
           " should be one of #{VALID_ORDERS.inspect[1..-2]}" unless VALID_ORDERS.include?(direction)
-        @current_set.replace [:order, @current_set.clone, expression, direction]
+        add_current_set_function :order, expression, direction
         self
       end
 
       %w(top bottom).each do |extreme|
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{extreme}_count(count, expression=nil)
-            raise ArgumentError, "cannot use #{extreme}_count method before axis or with_set method" unless @current_set
-            @current_set.replace [:#{extreme}_count, @current_set.clone, count]
-            @current_set << expression if expression
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{extreme}_count(count, expression = nil)
+            validate_current_set
+            add_current_set_function :#{extreme}_count, count, expression
             self
           end
         RUBY
 
         %w(percent sum).each do |extreme_name|
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def #{extreme}_#{extreme_name}(value, expression)
-              raise ArgumentError, "cannot use #{extreme}_#{extreme_name} method before axis or with_set method" unless @current_set
-              @current_set.replace [:#{extreme}_#{extreme_name}, @current_set.clone, value, expression]
+              validate_current_set
+              add_current_set_function :#{extreme}_#{extreme_name}, value, expression
               self
             end
           RUBY
@@ -139,20 +130,19 @@ module Mondrian
       end
 
       def hierarchize(order = nil, all = nil)
-        raise ArgumentError, "cannot use hierarchize method before axis or with_set method" unless @current_set
+        validate_current_set
         order = order && order.to_s.upcase
         raise ArgumentError, "invalid hierarchize order #{order.inspect}" unless order.nil? || order == 'POST'
-        if all.nil? && [:crossjoin, :nonempty_crossjoin].include?(@current_set[0])
-          @current_set[2] = [:hierarchize, @current_set[2]]
-          @current_set[2] << order if order
+        if all.nil?
+          add_last_set_function :hierarchize, order
         else
-          @current_set.replace [:hierarchize, @current_set.clone]
-          @current_set << order if order
+          add_current_set_function :hierarchize, order
         end
         self
       end
 
       def hierarchize_all(order = nil)
+        validate_current_set
         hierarchize(order, :all)
       end
 
@@ -249,7 +239,37 @@ module Mondrian
 
       private
 
-      # FIXME: keep original order of WITH MEMBER and WITH SET defitions
+      def validate_current_set
+        unless @current_set
+          method_name = caller_locations(1,1).first&.label
+          raise ArgumentError, "cannot use #{method_name} method before axis or with_set method"
+        end
+      end
+
+      def add_current_set_function(function_name, *args)
+        remove_last_nil_arg(args)
+        @current_set.replace [function_name, @current_set.clone, *args]
+      end
+
+      def add_last_set_function(function_name, *args)
+        remove_last_nil_arg(args)
+        if current_set_crossjoin?
+          @current_set[2] = [function_name, @current_set[2], *args]
+        else
+          add_current_set_function function_name, *args
+        end
+      end
+
+      def remove_last_nil_arg(args)
+        args.pop if args.length > 0 && args.last.nil?
+      end
+
+      CROSSJOIN_FUNCTIONS = [:crossjoin, :nonempty_crossjoin].freeze
+
+      def current_set_crossjoin?
+        CROSSJOIN_FUNCTIONS.include?(@current_set&.first)
+      end
+
       def with_to_mdx
         @with.map do |definition|
           case definition[0]
@@ -287,13 +307,13 @@ module Mondrian
       end
 
       MDX_FUNCTIONS = {
-        :top_count => 'TOPCOUNT',
-        :top_percent => 'TOPPERCENT',
-        :top_sum => 'TOPSUM',
-        :bottom_count => 'BOTTOMCOUNT',
-        :bottom_percent => 'BOTTOMPERCENT',
-        :bottom_sum => 'BOTTOMSUM'
-      }
+        top_count: 'TOPCOUNT',
+        top_percent: 'TOPPERCENT',
+        top_sum: 'TOPSUM',
+        bottom_count: 'BOTTOMCOUNT',
+        bottom_percent: 'BOTTOMPERCENT',
+        bottom_sum: 'BOTTOMSUM'
+      }.freeze
 
       def members_to_mdx(members)
         members ||= []

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -284,8 +284,15 @@ describe "Query" do
       end
 
       it "should filter using set alias" do
-        @query.rows('[Customers].[Country].Members').filter('NOT ISEMPTY(S.CURRENT)', :as => 'S')
+        @query.rows('[Customers].[Country].Members').filter('NOT ISEMPTY(S.CURRENT)', as: 'S')
         @query.rows.should == [:filter, ['[Customers].[Country].Members'], 'NOT ISEMPTY(S.CURRENT)', 'S']
+      end
+
+      it "should filter last set of nonempty_crossjoin" do
+        @query.rows('[Product].children').nonempty_crossjoin('[Customers].[Country].Members').
+          filter_last("[Customers].CurrentMember.Name = 'USA'")
+        @query.rows.should == [:nonempty_crossjoin, ['[Product].children'],
+          [:filter, ['[Customers].[Country].Members'], "[Customers].CurrentMember.Name = 'USA'"]]
       end
     end
 


### PR DESCRIPTION
This pull request refactors and enhances the `lib/mondrian/olap/query.rb` file by introducing helper methods to streamline the handling of set operations and improve code readability. It also includes minor updates to constants and test cases in `spec/query_spec.rb`. The most important changes focus on code modularization, validation improvements, and test coverage.

### Refactoring and modularization:
* Introduced helper methods `validate_current_set`, `add_current_set_function`, and `add_last_set_function` to encapsulate repeated logic for validating and modifying `@current_set`. This reduces code duplication and improves maintainability.
* Added `remove_last_nil_arg` to handle optional arguments more cleanly, and `current_set_crossjoin?` to check for crossjoin-related operations.

### Code improvements:
* Replaced inline `raise ArgumentError` checks with the new `validate_current_set` method across multiple functions (e.g., `filter`, `distinct`, `order`). This centralizes validation logic for better readability and consistency.
* Changed `MDX_FUNCTIONS` to use the modern hash syntax and added `.freeze` for immutability.

### Test enhancements:
* Added a new test case in `spec/query_spec.rb` to verify the behavior of `filter_last` with `nonempty_crossjoin`. This ensures the correctness of the refactored logic for filtering the last set in crossjoin operations.

### Minor updates:
* Updated `class_eval` blocks to use `<<~RUBY` for cleaner heredoc syntax.
* Simplified hash syntax in test cases for better readability.