### PR TITLE
Additional cube element methods

### DIFF
--- a/lib/mondrian/olap/query.rb
+++ b/lib/mondrian/olap/query.rb
@@ -404,7 +404,7 @@ module Mondrian
       def extract_dimension_name(full_name)
         # "[Foo [Bar]]].[Baz]" =>  "Foo [Bar]"
         if full_name
-          full_name.gsub(/\A\[|\]\z/, '').split('].[').first.try(:gsub, ']]', ']')
+          full_name.gsub(/\A\[|\]\z/, '').split('].[').first&.gsub(']]', ']')
         end
       end
     end

--- a/lib/mondrian/olap/result.rb
+++ b/lib/mondrian/olap/result.rb
@@ -507,7 +507,9 @@ module Mondrian
           max_alias_length = options[:max_alias_length]
           params = options[:params]
 
-          if table_name = (member.try(:getTableName) || member.try(:getMondrianDefExpression).try(:table))
+          if table_name = (member.respond_to?(:getTableName) && member.getTableName ||
+              member.respond_to?(:getMondrianDefExpression) && (expr = member.getMondrianDefExpression) &&
+              expr.respond_to?(:table) && expr.table)
             field[:quoted_table_name] = dialect.quoteIdentifier(table_name)
           end
 

--- a/spec/cube_spec.rb
+++ b/spec/cube_spec.rb
@@ -104,6 +104,10 @@ describe "Cube" do
     @olap.cube('Sales').should be_visible
   end
 
+  it "should not be virtual" do
+    @olap.cube('Sales').should_not be_virtual
+  end
+
   describe "dimensions" do
     before(:all) do
       @cube = @olap.cube('Sales')
@@ -115,7 +119,7 @@ describe "Cube" do
     end
 
     it "should get dimensions" do
-      @cube.dimensions.map{|d| d.name}.should == @dimension_names
+      @cube.dimensions.map(&:name).should == @dimension_names
     end
 
     it "should get dimension by name" do
@@ -226,6 +230,11 @@ describe "Cube" do
       @cube.dimension('Time').hierarchy.name.should == 'Time'
     end
 
+    it "should get hierarchy full name" do
+      @cube.dimension('Time').hierarchy.full_name.should == '[Time]'
+      @cube.dimension('Time').hierarchy('Time.Weekly').full_name.should == '[Time.Weekly]'
+    end
+
     it "should get hierarchy levels" do
       @cube.dimension('Customers').hierarchy.levels.map(&:name).should ==  ['(All)', 'Country', 'State Province', 'City', 'Name']
     end
@@ -322,6 +331,10 @@ describe "Cube" do
       @cube.dimension('Gender').hierarchy.level('Gender').caption.should == 'Gender level caption'
     end
 
+    it "should get level full name" do
+      @cube.dimension('Gender').hierarchy.level('Gender').full_name.should == '[Gender].[Gender]'
+    end
+
     it "should return nil when getting level with invalid name" do
       @cube.dimension('Gender').hierarchy.level('invalid').should be_nil
     end
@@ -334,6 +347,18 @@ describe "Cube" do
     it "should get secondary hierarchy level members" do
       @cube.dimension('Time').hierarchy('Time.Weekly').level('Year').members.
         map(&:name).should == ['2010', '2011']
+    end
+
+    it "should get child level" do
+      @cube.dimension('Customers').hierarchy.level('Country').child_level.name.should == 'State Province'
+    end
+
+    it "should get parent level" do
+      @cube.dimension('Customers').hierarchy.level('State Province').parent_level.name.should == 'Country'
+    end
+
+    it "should get descendant level" do
+      @cube.dimension('Customers').hierarchy.level('Country').descendant_level('City').name.should == 'City'
     end
 
     it "should get level annotations" do
@@ -381,7 +406,17 @@ describe "Cube" do
     end
 
     it "should return empty children array if member does not have children" do
-      @cube.member('[Gender].[All Genders].[F]').children.should be_empty
+      @cube.member('[Gender].[F]').children.should be_empty
+    end
+
+    it "should return children count for member" do
+      @cube.member('[Gender].[All Genders]').children_count.should == 2
+      @cube.member('[Customers].[USA].[OR]').children_count.should == 11
+      @cube.member('[Gender].[F]').children_count.should == 0
+    end
+
+    it "should return member level" do
+      @cube.member('[Customers].[USA]').level.name.should == 'Country'
     end
 
     it "should return member depth" do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1037,6 +1037,10 @@ describe "Query" do
         execute
     end
 
+    it "should be virtual cube" do
+      @olap.cube('Sales and Warehouse').should be_virtual
+    end
+
     it "should return specified fields from other cubes as empty strings" do
       @drill_through = @result.drill_through(:row => 0, :column => 3, :return => [
         '[Time].[Month]',


### PR DESCRIPTION
This pull request enhances the functionality of the `Mondrian::OLAP::Cube` class, improves code readability by replacing block syntax with the `&:` shorthand, and adds new tests to ensure coverage for the introduced features. The most important changes include the addition of methods to support virtual cubes, hierarchy and level navigation, and member-level operations.

### Enhancements to `Mondrian::OLAP::Cube` functionality:
* Added `mondrian_cube` and `virtual?` methods to support virtual cube identification.
* Added methods for hierarchy and level navigation, including `child_level`, `parent_level`, and `descendant_level`.
* Added `children_count` and `level` methods to retrieve member-specific details such as the number of children and associated level.

### Code readability improvements:
* Replaced block syntax with `&:` shorthand in methods like `hierarchy_names`, `level_names`, `root_member_names`, and `child_names`. [[1]](diffhunk://#diff-d02f87a268859f59f234598799a7c340ee644c3946de7c65822a1bea97c1a162L149-R159) [[2]](diffhunk://#diff-d02f87a268859f59f234598799a7c340ee644c3946de7c65822a1bea97c1a162L216-R230) [[3]](diffhunk://#diff-d02f87a268859f59f234598799a7c340ee644c3946de7c65822a1bea97c1a162L236-R254) [[4]](diffhunk://#diff-d02f87a268859f59f234598799a7c340ee644c3946de7c65822a1bea97c1a162L251-R265)
* Updated `quote_value` method to use the safe navigation operator (`&.`) for cleaner code.

### Test coverage additions:
* Added tests for virtual cube functionality, hierarchy full names, level navigation, and member-level operations in `spec/cube_spec.rb`. [[1]](diffhunk://#diff-a40b3b7e9b8bf3aaf00fe4310857f0b919f8855fa72606dca730b768d9d168ddR107-R110) [[2]](diffhunk://#diff-a40b3b7e9b8bf3aaf00fe4310857f0b919f8855fa72606dca730b768d9d168ddR233-R237) [[3]](diffhunk://#diff-a40b3b7e9b8bf3aaf00fe4310857f0b919f8855fa72606dca730b768d9d168ddR352-R363) [[4]](diffhunk://#diff-a40b3b7e9b8bf3aaf00fe4310857f0b919f8855fa72606dca730b768d9d168ddL384-R419)
* Added a test for virtual cubes in `spec/query_spec.rb`.